### PR TITLE
Add conversation and message storage helpers

### DIFF
--- a/task-orchestrator-pwa/src/types/index.ts
+++ b/task-orchestrator-pwa/src/types/index.ts
@@ -13,3 +13,17 @@ export interface LLMRequest {
 export interface LLMResponse {
   text: string
 }
+
+export interface Conversation {
+  id: string
+  title?: string
+  createdAt: string
+}
+
+export interface Message {
+  id: string
+  conversationId: string
+  role: string
+  content: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- expand IndexedDB schema with conversation and message stores
- provide helpers to manage conversations and their messages

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b999784ab8832db8a4d97fe3049205