### PR TITLE
Support conversations in LLM API routes

### DIFF
--- a/task-orchestrator-pwa/src/app/api/llm/route.ts
+++ b/task-orchestrator-pwa/src/app/api/llm/route.ts
@@ -1,11 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+interface Message {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { prompt, includeTasks, tasks } = await request.json() as {
-      prompt: string; includeTasks?: boolean; tasks?: Array<{id:string;text:string;completed:boolean;createdAt:string}>
+    const { conversationId, messages, includeTasks, tasks } = await request.json() as {
+      conversationId?: string
+      messages?: Message[]
+      includeTasks?: boolean
+      tasks?: Array<{ id: string; text: string; completed: boolean; createdAt: string }>
     }
-    if (!prompt) return NextResponse.json({ error: 'Prompt required' }, { status: 400 })
+
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: 'Messages required' }, { status: 400 })
+    }
+
+    const convId = conversationId || crypto.randomUUID()
 
     const ollamaUrl = process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
     const modelName = process.env.MODEL_NAME || 'llama3.1'
@@ -20,19 +33,28 @@ export async function POST(request: NextRequest) {
       ? `\n\nCurrent tasks:\n${tasks.slice(0,20).map(t => `- [${t.completed?'x':' '}] ${t.text}`).join('\n')}`
       : ''
 
+    const history = messages
+      .map(m => `${m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : 'System'}: ${m.content}`)
+      .join('\n\n')
+
     const response = await fetch(`${ollamaUrl}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         model: modelName,
-        prompt: `System: ${system}\n\nUser: ${prompt}${taskContext}`,
+        prompt: `System: ${system}\n\n${history}${taskContext}`,
         stream: false
       })
     })
 
     if (!response.ok) throw new Error(`Ollama API error: ${response.status}`)
     const data = await response.json()
-    return NextResponse.json({ text: data.response || 'No response from LLM' })
+    const text = data.response || 'No response from LLM'
+
+    return NextResponse.json({
+      conversationId: convId,
+      message: { role: 'assistant', content: text }
+    })
   } catch (error) {
     console.error('LLM API error:', error)
     return NextResponse.json({ error: 'LLM request failed' }, { status: 500 })

--- a/task-orchestrator-pwa/src/app/api/llm/stream/route.ts
+++ b/task-orchestrator-pwa/src/app/api/llm/stream/route.ts
@@ -1,9 +1,26 @@
 import { NextRequest } from 'next/server'
 
+interface Message {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
 export const runtime = 'nodejs'
 
 export async function POST(req: NextRequest) {
-  const { prompt, includeTasks, tasks } = await req.json()
+  const { conversationId, messages, includeTasks, tasks } = await req.json() as {
+    conversationId?: string
+    messages?: Message[]
+    includeTasks?: boolean
+    tasks?: Array<{ id: string; text: string; completed: boolean; createdAt: string }>
+  }
+
+  if (!messages || !Array.isArray(messages) || messages.length === 0) {
+    return new Response('Messages required', { status: 400 })
+  }
+
+  const convId = conversationId || crypto.randomUUID()
+
   const ollamaUrl = process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
   const modelName = process.env.MODEL_NAME || 'llama3.1'
 
@@ -12,12 +29,16 @@ export async function POST(req: NextRequest) {
     ? `\n\nCurrent tasks:\n${tasks.slice(0,20).map((t:any) => `- [${t.completed?'x':' '}] ${t.text}`).join('\n')}`
     : ''
 
+  const history = messages
+    .map(m => `${m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : 'System'}: ${m.content}`)
+    .join('\n\n')
+
   const upstream = await fetch(`${ollamaUrl}/api/generate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       model: modelName,
-      prompt: `System: ${system}\n\nUser: ${prompt}${taskContext}`,
+      prompt: `System: ${system}\n\n${history}${taskContext}`,
       stream: true
     })
   })
@@ -52,7 +73,10 @@ export async function POST(req: NextRequest) {
   })()
 
   return new Response(ts.readable, {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Conversation-Id': convId
+    }
   })
 }
 

--- a/task-orchestrator-pwa/tests/llm.test.ts
+++ b/task-orchestrator-pwa/tests/llm.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { POST } from '@/app/api/llm/route'
 
 describe('LLM API', () => {
-  it('400 without prompt', async () => {
+  it('400 without messages', async () => {
     const req = new Request('http://test/llm', { method:'POST', body: JSON.stringify({}) })
     const res = await POST(req as any)
     expect(res.status).toBe(400)


### PR DESCRIPTION
## Summary
- accept `{conversationId, messages}` payloads in LLM API routes
- include prior messages in prompts and return assistant reply with conversation ID
- expose conversation ID via header for streaming responses
- adjust test for new contract

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99979c4d4832da6d70b5f74a3cccf